### PR TITLE
Allow loading any driver

### DIFF
--- a/lib/Storage.js
+++ b/lib/Storage.js
@@ -168,7 +168,15 @@ module.exports = class Storage {
 		if (driver === 'memory') {
 			this.db = new (require('../drivers/db/Memory'))(options);
 		} else {
-			this.db = new (require(`@sapling/db-driver-${driver}`))(options);
+			try {
+				this.db = new (require(`@sapling/db-driver-${driver}`))(options);
+			} catch {
+				try {
+					this.db = new (require(driver))(options);
+				} catch {
+					throw new SaplingError(`Cannot find any DB driver for '${driver}'`);
+				}
+			}
 		}
 
 		await this.db.connect(dbConfig);

--- a/lib/Templating.js
+++ b/lib/Templating.js
@@ -12,6 +12,8 @@
 const path = require('path');
 const _ = require('underscore');
 
+const SaplingError = require('./SaplingError');
+
 
 /**
  * The Templating class
@@ -41,7 +43,15 @@ module.exports = class Templating {
 		if (driver === 'html') {
 			this.renderer = new (require('../drivers/render/Html'))(App, this.viewsPath);
 		} else {
-			this.renderer = new (require(`@sapling/render-driver-${driver}`))(App, this.viewsPath);
+			try {
+				this.renderer = new (require(`@sapling/render-driver-${driver}`))(App, this.viewsPath);
+			} catch {
+				try {
+					this.renderer = new (require(driver))(App, this.viewsPath);
+				} catch {
+					throw new SaplingError(`Cannot find any render driver for '${driver}'`);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This change allows the user to define any npm dep or file path as the value for `render.driver` or `db.driver` in config - in effect, allowing unofficial drivers to be written, published and loaded.

Closes #142 