### PR TITLE
Add unique index support for Memory

### DIFF
--- a/drivers/db/Interface.js
+++ b/drivers/db/Interface.js
@@ -48,10 +48,9 @@ module.exports = class Interface {
 	 * Create an index for the specified fields
 	 *
 	 * @param {string} collection Name of the target collection
-	 * @param {object} fields List of field names that should have indexes created. Key is the field name, value is the type of index
-	 * @param {object} config Driver specific options for the operation
+	 * @param {object} fields Object of indices to create.  Key is field name, value is index type, e.g. 'unique'
 	 */
-	async createIndex(collection, fields, config) {
+	async createIndex(collection, fields) {
 		throw new SaplingError('Method not implemented: createIndex');
 	}
 

--- a/lib/Storage.js
+++ b/lib/Storage.js
@@ -196,7 +196,7 @@ module.exports = class Storage {
 				for (const key in fields) {
 					/* Create indices for any fields marked unique or identifiable */
 					if (fields[key].unique || fields[key].identifiable) {
-						await this.db.createIndex(collection, { [key]: 1 }, { unique: true });
+						await this.db.createIndex(collection, { [key]: 'unique' });
 					}
 				}
 			}
@@ -660,7 +660,11 @@ module.exports = class Storage {
 			}
 
 			/* Send to the database */
-			return await this.db.modify(request.collection, conditions, data);
+			try {
+				return await this.db.modify(request.collection, conditions, data);
+			} catch (error) {
+				return new Response(this.app, request, response, new SaplingError(error));
+			}
 		}
 		/* If we're creating a new record */
 
@@ -673,7 +677,11 @@ module.exports = class Storage {
 		data._created = Date.now();
 
 		/* Send to the database */
-		return await this.db.write(request.collection, data);
+		try {
+			return await this.db.write(request.collection, data);
+		} catch (error) {
+			return new Response(this.app, request, response, new SaplingError(error));
+		}
 	}
 
 


### PR DESCRIPTION
Adds support for `unique` indices in the `Memory` driver.

**Important:** Redesigned the `createIndex` method, so the MongoDB driver will have to adapt as well.

Requires for the first time the ability for a DB driver to throw errors. Not sure if the catching in `Storage` is the best it could be, as for some reason this `Response` is always JSON.

Closes #154.