### PR TITLE
Normalise access

### DIFF
--- a/core/loadModel.js
+++ b/core/loadModel.js
@@ -49,10 +49,19 @@ module.exports = async function (next) {
 			/* Attempt to parse the JSON */
 			const parsedModel = JSON.parse(model.toString());
 
-			/* Convert string-based definitions into their object-based normals */
 			for (const rule of Object.keys(parsedModel)) {
+				/* Convert string-based definitions into their object-based normals */
 				if (typeof parsedModel[rule] === 'string') {
 					parsedModel[rule] = { type: parsedModel[rule] };
+				}
+
+				/* Normalise access definition */
+				if ('access' in parsedModel[rule]) {
+					if (typeof parsedModel[rule].access === 'string') {
+						parsedModel[rule].access = { r: parsedModel[rule].access, w: parsedModel[rule].access };
+					}
+				} else {
+					parsedModel[rule].access = { r: 'anyone', w: 'anyone' };
 				}
 			}
 

--- a/lib/Storage.js
+++ b/lib/Storage.js
@@ -22,10 +22,10 @@ const Validation = require('./Validation');
 /* Extensible through a users model */
 const userStructure = {
 	email: { type: 'String', minlen: 3, email: true, unique: true, required: true, identifiable: true },
-	password: { type: 'String', minlen: 3, required: true, access: 'owner' },
-	_salt: { type: 'String', access: 'owner' },
+	password: { type: 'String', minlen: 3, required: true, access: { r: 'owner', w: 'owner' } },
+	_salt: { type: 'String', access: { r: 'owner', w: 'owner' } },
 	role: { type: 'String', values: ['admin', 'member'], default: 'member', access: { r: 'anyone', w: 'admin' } },
-	_authkey: { type: 'String', access: 'owner' }
+	_authkey: { type: 'String', access: { r: 'owner', w: 'owner' } }
 };
 
 

--- a/test/_data/models/access/posts.json
+++ b/test/_data/models/access/posts.json
@@ -1,0 +1,19 @@
+{
+	"title": {
+		"type": "string",
+		"required": true,
+		"maxlen": 140,
+		"access": {
+			"r": "anyone",
+			"w": "owner"
+		}
+	},
+	"viewCount": {
+		"type": "number",
+		"default": 0,
+		"access": "anyone"
+	},
+	"content": {
+		"type": "string"
+	}
+}

--- a/test/core/loadModel.test.js
+++ b/test/core/loadModel.test.js
@@ -54,6 +54,32 @@ test('loads object based model definition', async t => {
 	t.is(t.context.app.structure.posts.viewCount.default, 0);
 });
 
+test('normalises access object', async t => {
+	t.context.app.config.modelsDir = 'test/_data/models/access';
+
+	await t.notThrowsAsync(async () => {
+		await loadModel.call(t.context.app);
+	});
+
+	t.true('posts' in t.context.app.structure);
+	t.true('title' in t.context.app.structure.posts);
+	t.true('viewCount' in t.context.app.structure.posts);
+	t.true('content' in t.context.app.structure.posts);
+	t.true('access' in t.context.app.structure.posts.title);
+	t.true('access' in t.context.app.structure.posts.viewCount);
+	t.true('access' in t.context.app.structure.posts.content);
+	t.true(_.isObject(t.context.app.structure.posts.title.access));
+	t.true(_.isObject(t.context.app.structure.posts.viewCount.access));
+	t.true(_.isObject(t.context.app.structure.posts.content.access));
+
+	t.is(t.context.app.structure.posts.title.access.r, 'anyone');
+	t.is(t.context.app.structure.posts.title.access.w, 'owner');
+	t.is(t.context.app.structure.posts.viewCount.access.r, 'anyone');
+	t.is(t.context.app.structure.posts.viewCount.access.w, 'anyone');
+	t.is(t.context.app.structure.posts.content.access.r, 'anyone');
+	t.is(t.context.app.structure.posts.content.access.w, 'anyone');
+});
+
 test('throws an error for a mangled model definition', async t => {
 	t.context.app.config.modelsDir = 'test/_data/models/mangled';
 


### PR DESCRIPTION
Makes sure that every model field has a predictably formatted access object, regardless of whether or how it's defined.

Closes #162.