### PR TITLE
Convert from Express to tinyhttp

### DIFF
--- a/core/loadServer.js
+++ b/core/loadServer.js
@@ -11,7 +11,8 @@ const { Cluster } = require('../lib/Cluster');
 const Response = require('../lib/Response');
 const SaplingError = require('../lib/SaplingError');
 
-const express = require('express');
+const { App: TinyHTTP } = require('@tinyhttp/app');
+const sirv = require('sirv');
 const session = require('express-session');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
@@ -34,7 +35,7 @@ module.exports = function ({ reload, listen }, next) {
 		// This.server.routes = server._router.map;
 		// this.server.stack.length = 2;
 	} else {
-		server = express();
+		server = new TinyHTTP();
 		this.routeStack = { get: [], post: [], delete: [] };
 	}
 
@@ -82,7 +83,7 @@ module.exports = function ({ reload, listen }, next) {
 		/* Loop through it */
 		for (const publicDir of this.config.publicDir) {
 			const publicDirPath = path.join(this.dir, publicDir);
-			server.use(`/${publicDir}`, express.static(publicDirPath, { maxAge: 1 }));
+			server.use(`/${publicDir}`, sirv(publicDirPath, { maxAge: 1 }));
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -664,10 +664,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.12",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.12.tgz",
+      "integrity": "sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ=="
+    },
     "@sapling/sapling": {
       "version": "file:",
       "dev": true,
       "requires": {
+        "@tinyhttp/app": "^1.3.3",
         "async": "^3.2.0",
         "body-parser": "1.19.0",
         "chalk": "^4.1.0",
@@ -675,16 +681,20 @@
         "cookie-parser": "1.4.5",
         "cron": "^1.7.1",
         "csurf": "^1.11.0",
-        "express": "4.17.1",
         "express-fileupload": "^1.2.1",
         "express-session": "1.17.1",
         "filenamify": "^4.2.0",
         "front-matter": "^4.0.2",
+        "image-size": "^1.0.0",
         "isobject": "^4.0.0",
         "moment": "2.29.1",
         "morgan": "^1.9.1",
+        "nodemailer": "6.6.0",
         "path-match": "^1.2.4",
-        "unused-filename": "^2.1.0"
+        "sirv": "^1.0.11",
+        "underscore": "1.13.1",
+        "unused-filename": "^2.1.0",
+        "yargs": "^17.0.1"
       }
     },
     "@sindresorhus/is": {
@@ -701,6 +711,131 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@tinyhttp/accepts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/accepts/-/accepts-1.3.0.tgz",
+      "integrity": "sha512-YaJ4EMgVUI6JHzWO14lr6vn/BLJEoFN4Sqd20l0/oBcLLENkP8gnPtX1jB7OhIu0AE40VCweAqvSP+0/pgzB1g==",
+      "requires": {
+        "es-mime-types": "^0.0.16",
+        "negotiator": "^0.6.2"
+      }
+    },
+    "@tinyhttp/app": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/app/-/app-1.3.3.tgz",
+      "integrity": "sha512-PhE3En3AMWNcdrm0hVTcawz5UIWUlzHo5Zl+JunOXR2hhXJ9afvm6OCXg0GX/bgNZ1vW/Prwp10+KrGWygthnQ==",
+      "requires": {
+        "@tinyhttp/cookie": "1.3.0",
+        "@tinyhttp/proxy-addr": "1.3.0",
+        "@tinyhttp/req": "1.3.0",
+        "@tinyhttp/res": "1.3.0",
+        "@tinyhttp/router": "1.3.1",
+        "regexparam": "^1.3.0"
+      }
+    },
+    "@tinyhttp/content-disposition": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-1.3.0.tgz",
+      "integrity": "sha512-sSj7YDVz7NcHDn6/O/I3WjtC8ZWJKKIGULoV+pgrLvJvtXK5WroE1Fm8rHRQewh2d9NMajh/7NX6NuSlF8LUaQ=="
+    },
+    "@tinyhttp/cookie": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/cookie/-/cookie-1.3.0.tgz",
+      "integrity": "sha512-4ZVfP8WApV9ZRchv/1i0QiKdP0wxWTUNv4ZsMQrqK0p1KXA0/SvpYUTS6bp1E6Yo0dNxcKte4wJ4FCWFDcShhQ=="
+    },
+    "@tinyhttp/cookie-signature": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/cookie-signature/-/cookie-signature-1.3.0.tgz",
+      "integrity": "sha512-xCQZyCT1S/Rn2Z3SX2gp4IDAwW9AUnjky6hKvqzmMaQqEbIk7e2GCOXW5yjndbfGNTJAxj0tuLNMF4G8aLkfMw=="
+    },
+    "@tinyhttp/encode-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/encode-url/-/encode-url-0.3.0.tgz",
+      "integrity": "sha512-QM5j5t0GLucBuBePoOilcz1/zDpqX+LtUdtkPn7IvoHTNJYNxEfSUmIMPUPhyVY7mvbwvafPUCK8u1Byx0+NfQ=="
+    },
+    "@tinyhttp/etag": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/etag/-/etag-1.3.0.tgz",
+      "integrity": "sha512-aWnDb4NuMf/UTm1H88rZgqu32E6t3iDHSHtAppiQCH4M7jRfTUEpiZjz//S+giDnOxAuYttLrXQ1+HGpgzyYUQ=="
+    },
+    "@tinyhttp/forwarded": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/forwarded/-/forwarded-1.3.0.tgz",
+      "integrity": "sha512-U2FPtOH+DoFtd98edMRyqiquRaiuEl5I2PMUWdKaBSpiAIR96buyanQ7hScenz1MihK0AVid7wLAviaJU+Xlyg=="
+    },
+    "@tinyhttp/proxy-addr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/proxy-addr/-/proxy-addr-1.3.0.tgz",
+      "integrity": "sha512-7Kv6YIC/PlhUwyqAGXhg4DoQDOzbYlcGPkNv/KZAMFj9fZ6IEZyneyaClnD21hMT8qa7g3Z/66hxLa/WxiPAYA==",
+      "requires": {
+        "@tinyhttp/forwarded": "^1.3.0",
+        "ipaddr.js": "^2.0.0"
+      },
+      "dependencies": {
+        "ipaddr.js": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+          "integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w=="
+        }
+      }
+    },
+    "@tinyhttp/req": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/req/-/req-1.3.0.tgz",
+      "integrity": "sha512-zIbtJA7Hp2p4MqszP2jOBi2NWi8fTGd4lso+0CjwJa+WTE+lgXVAy6mN12rTAxjXweAyRvQpRIJ5W2r8OLuEXQ==",
+      "requires": {
+        "@tinyhttp/accepts": "1.3.0",
+        "@tinyhttp/type-is": "1.3.0",
+        "@tinyhttp/url": "1.3.0",
+        "es-fresh": "^0.0.8",
+        "range-parser": "^1.2.1"
+      }
+    },
+    "@tinyhttp/res": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/res/-/res-1.3.0.tgz",
+      "integrity": "sha512-ez6fCpGsYoU6HUBq0e+m4l6Cffu2FeucK+m5Z6a8sBGqLR7/teB1pFufCOPwrdwzdNrLNarGJpsNQpvQqDMWaA==",
+      "requires": {
+        "@tinyhttp/content-disposition": "1.3.0",
+        "@tinyhttp/cookie": "1.3.0",
+        "@tinyhttp/cookie-signature": "1.3.0",
+        "@tinyhttp/encode-url": "0.3.0",
+        "@tinyhttp/req": "1.3.0",
+        "@tinyhttp/send": "1.3.0",
+        "es-mime-types": "^0.0.16",
+        "es-vary": "^0.0.8",
+        "escape-html": "^1.0.3"
+      }
+    },
+    "@tinyhttp/router": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/router/-/router-1.3.1.tgz",
+      "integrity": "sha512-r+VTBrRVxCgkTUVOzR2Awzaqa8DCQKQg/BLIpKEHNGp/OVuxSvVGVIEKiZZY9Z5E3HR6FYZL0TMO7r6QvzP1Jg=="
+    },
+    "@tinyhttp/send": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/send/-/send-1.3.0.tgz",
+      "integrity": "sha512-3Tn8NaLhNdcIJQqc/3ZBFV0hX6jCaFNDX5/vWxoPubDrh8HOpn2foPXL7ZIRk8GDkaB/M3cSzKIlKpnTKmh0Nw==",
+      "requires": {
+        "@tinyhttp/etag": "1.3.0",
+        "es-content-type": "^0.0.10",
+        "es-mime-types": "^0.0.16"
+      }
+    },
+    "@tinyhttp/type-is": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/type-is/-/type-is-1.3.0.tgz",
+      "integrity": "sha512-3NClOYPNJst9vVLcb793epRI+ZuRwl6IjxSq9LkGN8TEBbtNgv2vTmXZRWcUs2zY9Ju+NQIYecWcsG0Kx23E+g==",
+      "requires": {
+        "es-content-type": "^0.0.10",
+        "es-mime-types": "^0.0.16"
+      }
+    },
+    "@tinyhttp/url": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/url/-/url-1.3.0.tgz",
+      "integrity": "sha512-GgdKez5AaQRIm0kFNp7BZnxFQ2F7LZ7g3rOQ/v11oYZR3jhH7JPGM+7hZQjYqFXD/5TK/of7hepu418K2fghvg=="
     },
     "@types/eslint": {
       "version": "7.2.10",
@@ -1316,7 +1451,8 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
     },
     "array-includes": {
       "version": "3.1.3",
@@ -2446,6 +2582,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -2903,7 +3040,8 @@
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "dicer": {
       "version": "0.3.0",
@@ -3025,7 +3163,8 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3183,6 +3322,24 @@
         "unbox-primitive": "^1.0.0"
       }
     },
+    "es-content-type": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/es-content-type/-/es-content-type-0.0.10.tgz",
+      "integrity": "sha512-yCgcv1M2IuFUoGZ3zE4OR2INGmZOwEuyaE5WX4MOKGpJcO8JXgVOIcXVicwnTqlxvx6qs9IJGl/Rr1+YtCkRgg=="
+    },
+    "es-fresh": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/es-fresh/-/es-fresh-0.0.8.tgz",
+      "integrity": "sha512-ZM+K/T/zHJVuOhaz19iymidACazB1fl2uihBtSfRie8YzN1YM+KldVmNaU+GSmVvTOPSO2utKOhxcOinr5tKjw=="
+    },
+    "es-mime-types": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/es-mime-types/-/es-mime-types-0.0.16.tgz",
+      "integrity": "sha512-84QoSLeA7cdTeHpALFNl3ZOstXfvLt426/kaOgmSxmNUOhi4GesKVkhJgIfnsqGNziYezVA8rvZUsXj7oWX2qQ==",
+      "requires": {
+        "mime-db": "^1.44.0"
+      }
+    },
     "es-module-lexer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
@@ -3199,6 +3356,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es-vary": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/es-vary/-/es-vary-0.0.8.tgz",
+      "integrity": "sha512-fiERjQiCHrXUAToNRT/sh7MtXnfei9n7cF9oVQRUEp9L5BGXsTKSPaXq8L+4v0c/ezfvuTWd/f0JSl5IBRUvSg=="
     },
     "es6-error": {
       "version": "4.1.1",
@@ -3866,7 +4028,8 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
     },
     "events": {
       "version": "3.3.0",
@@ -3951,6 +4114,7 @@
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
@@ -4225,6 +4389,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -4323,7 +4488,8 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -4337,7 +4503,8 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fromentries": {
       "version": "1.3.2",
@@ -4949,7 +5116,8 @@
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true
     },
     "ipv6-normalize": {
       "version": "1.0.1",
@@ -6025,7 +6193,8 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -6042,7 +6211,8 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
     },
     "micro-spelling-correcter": {
       "version": "1.1.1",
@@ -6081,7 +6251,8 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.46.0",
@@ -7048,7 +7219,8 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -7239,6 +7411,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
       "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
@@ -7585,6 +7758,11 @@
       "integrity": "sha512-+7HWfb4Bvu8Rs2eQTUIpX9I/PlQkYOuTNbRpKLJlQpSgwSkzFYh+pUj0gtvglnOZLKB6YgnIgRuJ2/IlpL48qw==",
       "dev": true
     },
+    "regexparam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-1.3.0.tgz",
+      "integrity": "sha512-6IQpFBv6e5vz1QAqI+V4k8P2e/3gRrqfCJ9FI+O1FLQTO+Uz6RXZEZOPmTJ6hlGj7gkERzY5BRCv09whKP96/g=="
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -7818,6 +7996,7 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -7837,7 +8016,8 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -7871,6 +8051,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -7974,6 +8155,23 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "sirv": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.11.tgz",
+      "integrity": "sha512-SR36i3/LSWja7AJNRBz4fF/Xjpn7lQFI30tZ434dIy+bitLYSP+ZEenHg36i23V2SGEz+kqjksg0uOGZ5LPiqg==",
+      "requires": {
+        "@polka/url": "^1.0.0-next.9",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        }
+      }
     },
     "slash": {
       "version": "3.0.0",
@@ -8954,6 +9152,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g=="
+    },
     "trim-newlines": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
@@ -9285,7 +9488,8 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
     },
     "uue": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "bin": "./index.js",
   "dependencies": {
+    "@tinyhttp/app": "^1.3.3",
     "async": "^3.2.0",
     "body-parser": "1.19.0",
     "chalk": "^4.1.0",
@@ -32,7 +33,6 @@
     "cookie-parser": "1.4.5",
     "cron": "^1.7.1",
     "csurf": "^1.11.0",
-    "express": "4.17.1",
     "express-fileupload": "^1.2.1",
     "express-session": "1.17.1",
     "filenamify": "^4.2.0",
@@ -43,6 +43,7 @@
     "morgan": "^1.9.1",
     "nodemailer": "6.6.0",
     "path-match": "^1.2.4",
+    "sirv": "^1.0.11",
     "underscore": "1.13.1",
     "unused-filename": "^2.1.0",
     "yargs": "^17.0.1"

--- a/test/core/loadRest.test.js
+++ b/test/core/loadRest.test.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const _ = require('underscore');
-const express = require('express');
+const { App: TinyHTTP } = require('@tinyhttp/app');
 const request = require('supertest');
 
 const Storage = require('../../lib/Storage');
@@ -14,7 +14,7 @@ test.beforeEach(t => {
 		name: 'test'
 	}, require('../_utils/app')());
 
-	t.context.app.server = express();
+	t.context.app.server = new TinyHTTP();
 
 	t.context.app.storage = new Storage(t.context.app, {
 		name: 'test',


### PR DESCRIPTION
Spike PR to explore converting from Express to tinyhttp, to see how difficult it is, and what kind of performance boost it may provide.

Closes #97.

### Notes
- Chose to rename the imported `App` to `TinyHTTP` in order to avoid wider confusion with the pre-existing Sapling `App` object.
- tinyhttp doesn't do static assets out of the box, this requires a separate dependency; went with `sirv`, seems to be a seamless drop-in replacement
- The missing 9% of code coverage accounts for some very key parts of the app, so some manual testing will be required