### PR TITLE
Fix rmdirSync deprecation notice

### DIFF
--- a/test/lib/Uploads.test.js
+++ b/test/lib/Uploads.test.js
@@ -460,5 +460,9 @@ test('does not process a non-file field in strict mode', async t => {
 
 
 test.after.always(t => {
-	fs.rmdirSync(path.join(__dirname, 'uploads'), { recursive: true });
+	if (typeof fs.rmSync === 'function') {
+		fs.rmSync(path.join(__dirname, 'uploads'), { recursive: true });
+	} else {
+		fs.rmdirSync(path.join(__dirname, 'uploads'), { recursive: true });
+	}
 });


### PR DESCRIPTION
The Uploads test suite triggers [DEP0147](https://nodejs.org/api/deprecations.html#DEP0147) in Node, as recursive `fs.rmdirSync` will be removed in the future.

However, using the suggested alternative of `fs.rmSync` doesn't work for Node.js 12, so the fix requires calling the new method only if it is available, and using the current code as a fallback.