### PR TITLE
Remove strict mode from Interfaces

### DIFF
--- a/drivers/db/Interface.js
+++ b/drivers/db/Interface.js
@@ -6,8 +6,6 @@
  * in whatever way makes sense for the particular database technology.
  */
 
-'use strict';
-
 
 /* Dependencies */
 import SaplingError from '../../lib/SaplingError.js';

--- a/drivers/render/Interface.js
+++ b/drivers/render/Interface.js
@@ -7,8 +7,6 @@
  * database technology.
  */
 
-'use strict';
-
 
 /* Dependencies */
 import SaplingError from '../../lib/SaplingError.js';


### PR DESCRIPTION
As part of #222 and #247, all instances of strict mode were removed. However, the linter is told to ignore `Interface` files, so the strict mode declarations there remained.