### PR TITLE
Swap test commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "precommit": "lint-staged",
     "lint-fix": "xo --fix",
     "lint": "xo",
-    "test": "npx c8 ava",
-    "test:nocov": "npx ava",
+    "test": "npx ava",
+    "test:coverage": "npx c8 ava",
     "test:report": "npx c8 --reporter=lcov npm test",
     "test:send": "npx codecov"
   },


### PR DESCRIPTION
Swap test npm scripts so that coverage is not calculated by default, and the `test:coverage` script must be run to run it through `c8`. This is because it's very slow, and typically not needed in development constantly. Makes local test runs much faster, and perhaps CI test runs a bit faster too?