### PR TITLE
Use `matchWildcard` for Memory driver

### DIFF
--- a/drivers/db/Memory.js
+++ b/drivers/db/Memory.js
@@ -189,7 +189,7 @@ export default class Memory extends Interface {
 
 				/* If we have wildcards, build a regex */
 				if (String(value).includes('*')) {
-					return String(record[field]).match(new RegExp(`^${value.split('*').join('(.*)')}$`, 'gmi')) !== null;
+					return new Utils().matchWildcard(record[field], value);
 				}
 
 				/* Otherwise do a direct match */

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -127,7 +127,7 @@ export default class Utils {
 	 */
 	matchWildcard(string, rule) {
 		const escapeRegex = string => string.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1');
-		return new RegExp(`^${String(rule).split('*').map(element => escapeRegex(element)).join('.*')}$`).test(String(string));
+		return new RegExp(`^${String(rule).split('*').map(element => escapeRegex(element)).join('.*')}$`, 'i').test(String(string));
 	}
 
 


### PR DESCRIPTION
#416 introduced a `matchWildcard` method for generally supporting matching patterns with asterisk based wildcards.

This PR implements that method for the Memory DB driver.