### PR TITLE
Implement options in Memory driver

### DIFF
--- a/lib/Storage.js
+++ b/lib/Storage.js
@@ -267,7 +267,7 @@ export default class Storage {
 		const limit = (this.app.config.limit && this.app.config.limit > 0) ? this.app.config.limit : false;
 
 		/* Parse limit options */
-		if ('limit' in request.query) {
+		if ('limit' in request.query && Number(request.query.limit) !== 0) {
 			options.limit = Number(request.query.limit) || null;
 
 			/* If max limit is set in config, ensure we don't go over it */

--- a/test/drivers/db/Memory.test.js
+++ b/test/drivers/db/Memory.test.js
@@ -193,6 +193,35 @@ test.serial('reads nothing in a non-existent collection', async t => {
 	t.is(results.length, 0);
 });
 
+test.serial('limits records according to limit option', async t => {
+	const results = await t.context.memory.read('fifth', {}, { limit: 2 });
+
+	t.true(Array.isArray(results));
+	t.is(results.length, 2);
+});
+
+test.serial('skips records according to skip option', async t => {
+	const results = await t.context.memory.read('fifth', {}, { limit: 2, skip: 2 });
+
+	t.true(Array.isArray(results));
+	t.is(results.length, 2);
+	t.is(results[0].name, 'North Yorkshire');
+});
+
+test.serial('sorts records ascending according to sort option', async t => {
+	const results = await t.context.memory.read('fifth', {}, { sort: [ [ 'name', 1 ] ] });
+
+	t.true(Array.isArray(results));
+	t.is(results[0].name, 'Hamptons');
+});
+
+test.serial('sorts records descending according to sort option', async t => {
+	const results = await t.context.memory.read('fifth', {}, { sort: [ [ 'name', -1 ] ] });
+
+	t.true(Array.isArray(results));
+	t.is(results[0].name, 'North Yorkshire');
+});
+
 test.serial('modifies one record by ID', async t => {
 	const results = await t.context.memory.modify('first', { _id: t.context.memory.memory.first[0]._id }, { new: 'hello' });
 


### PR DESCRIPTION
Implements the `limit`, `skip` and `sort` options in the Memory driver.

Closes #163 