### PR TITLE
Differentiate errors

### DIFF
--- a/core/loadPermissions.js
+++ b/core/loadPermissions.js
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { console } from '../lib/Cluster.js';
 import Response from '../lib/Response.js';
 import SaplingError from '../lib/SaplingError.js';
+import UnauthorizedError from '../lib/UnauthorizedError.js';
 
 
 /**
@@ -96,7 +97,7 @@ export default async function loadPermissions(next) {
 				if (request.permission.redirect) {
 					response.redirect(request.permission.redirect);
 				} else {
-					return new Response(this, request, response, new SaplingError('You do not have permission to complete this action.'));
+					return new Response(this, request, response, new UnauthorizedError());
 				}
 			} else {
 				next();

--- a/hooks/sapling/user/forgot.js
+++ b/hooks/sapling/user/forgot.js
@@ -11,6 +11,7 @@ import Redirect from '@sapling/sapling/lib/Redirect.js';
 import Response from '@sapling/sapling/lib/Response.js';
 import SaplingError from '@sapling/sapling/lib/SaplingError.js';
 import Validation from '@sapling/sapling/lib/Validation.js';
+import ValidationError from '@sapling/sapling/lib/ValidationError.js';
 
 
 /* Hook /api/user/forgot */
@@ -18,7 +19,7 @@ export default async function forgot(app, request, response) {
 	/* Check email for format */
 	const errors = new Validation().validate(request.body.email, 'email', { email: true, required: true });
 	if (errors.length > 0) {
-		return new Response(app, request, response, new SaplingError(errors));
+		return new Response(app, request, response, new ValidationError(errors));
 	}
 
 	/* Get authkey and identifiable from database */

--- a/hooks/sapling/user/login.js
+++ b/hooks/sapling/user/login.js
@@ -11,7 +11,7 @@ import _ from 'underscore';
 import Hash from '@sapling/sapling/lib/Hash.js';
 import Redirect from '@sapling/sapling/lib/Redirect.js';
 import Response from '@sapling/sapling/lib/Response.js';
-import SaplingError from '@sapling/sapling/lib/SaplingError.js';
+import ValidationError from '../../../lib/ValidationError.js';
 
 
 /* Hook /api/user/login */
@@ -47,7 +47,7 @@ export default async function login(app, request, response) {
 
 	/* If identValue wasn't assigned, reject request */
 	if (identValue === false) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '401',
 			code: '1001',
 			title: 'Invalid Input',
@@ -67,7 +67,7 @@ export default async function login(app, request, response) {
 
 	/* If no user is found, throw error */
 	if (data.length === 0) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '401',
 			code: '4001',
 			title: 'Invalid User or Password',
@@ -81,7 +81,7 @@ export default async function login(app, request, response) {
 
 	/* If no password was provided, throw error */
 	if (!request.body.password) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '422',
 			code: '1001',
 			title: 'Invalid Input',
@@ -109,7 +109,7 @@ export default async function login(app, request, response) {
 		delete request.session.user._salt;
 	} else {
 		/* Return an error if the password didn't match */
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '401',
 			code: '4001',
 			title: 'Invalid User or Password',

--- a/hooks/sapling/user/recover.js
+++ b/hooks/sapling/user/recover.js
@@ -9,14 +9,14 @@ import Hash from '@sapling/sapling/lib/Hash.js';
 
 import Redirect from '@sapling/sapling/lib/Redirect.js';
 import Response from '@sapling/sapling/lib/Response.js';
-import SaplingError from '@sapling/sapling/lib/SaplingError.js';
+import ValidationError from '@sapling/sapling/lib/ValidationError.js';
 
 
 /* Hook /api/user/recover */
 export default async function recover(app, request, response) {
 	/* If the new password has not been provided, throw error */
 	if (!request.body.new_password) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '422',
 			code: '1001',
 			title: 'Invalid Input',
@@ -36,12 +36,12 @@ export default async function recover(app, request, response) {
 	}, response);
 
 	if (validation.length > 0) {
-		return new Response(app, request, response, new SaplingError(validation));
+		return new Response(app, request, response, new ValidationError(validation));
 	}
 
 	/* If the auth key has not been provided, throw error */
 	if (!request.body.auth) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '422',
 			code: '1001',
 			title: 'Invalid Input',
@@ -61,7 +61,7 @@ export default async function recover(app, request, response) {
 
 	/* If the key has expired, show error */
 	if (Number.isNaN(diff) || diff <= 0) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '401',
 			code: '4003',
 			title: 'Authkey Expired',
@@ -81,7 +81,7 @@ export default async function recover(app, request, response) {
 
 	/* If there is no such user */
 	if (!user) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '401',
 			code: '4004',
 			title: 'Authkey Invalid',

--- a/hooks/sapling/user/register.js
+++ b/hooks/sapling/user/register.js
@@ -11,7 +11,7 @@ import { console } from '@sapling/sapling/lib/Cluster.js';
 import Hash from '@sapling/sapling/lib/Hash.js';
 import Redirect from '@sapling/sapling/lib/Redirect.js';
 import Response from '@sapling/sapling/lib/Response.js';
-import SaplingError from '@sapling/sapling/lib/SaplingError.js';
+import ValidationError from '../../../lib/ValidationError.js';
 
 
 /* Hook /api/user/register */
@@ -63,7 +63,7 @@ export default async function register(app, request, response) {
 	/* Show the above errors, if any */
 	const combinedErrors = [...errors, ...validation];
 	if (combinedErrors.length > 0) {
-		return new Response(app, request, response, new SaplingError(combinedErrors));
+		return new Response(app, request, response, new ValidationError(combinedErrors));
 	}
 
 	/* Hash the password, and add it to the request */

--- a/hooks/sapling/user/update.js
+++ b/hooks/sapling/user/update.js
@@ -10,14 +10,14 @@ import Hash from '@sapling/sapling/lib/Hash.js';
 
 import Redirect from '@sapling/sapling/lib/Redirect.js';
 import Response from '@sapling/sapling/lib/Response.js';
-import SaplingError from '@sapling/sapling/lib/SaplingError.js';
+import ValidationError from '@sapling/sapling/lib/ValidationError.js';
 
 
 /* Hook /api/user/update */
 export default async function update(app, request, response) {
 	/* If the user isn't logged in */
 	if (!request.session || !request.session.user) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '401',
 			code: '4002',
 			title: 'Unauthorized',
@@ -31,7 +31,7 @@ export default async function update(app, request, response) {
 
 	/* If password isn't provided */
 	if (!request.body.password) {
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '422',
 			code: '1001',
 			title: 'Invalid Input',
@@ -52,7 +52,7 @@ export default async function update(app, request, response) {
 		}, response);
 
 		if (validation.length > 0) {
-			return new Response(app, request, response, new SaplingError(validation));
+			return new Response(app, request, response, new ValidationError(validation));
 		}
 	}
 
@@ -84,7 +84,7 @@ export default async function update(app, request, response) {
 		delete request.body.new_password;
 	} else {
 		/* Throw error if password didn't match */
-		return new Response(app, request, response, new SaplingError({
+		return new Response(app, request, response, new ValidationError({
 			status: '422',
 			code: '1009',
 			title: 'Incorrect Password',

--- a/lib/Response.js
+++ b/lib/Response.js
@@ -13,6 +13,7 @@ import { console } from './Cluster.js';
 import Redirect from './Redirect.js';
 import Templating from './Templating.js';
 import Utils from './Utils.js';
+import UnauthorizedError from './UnauthorizedError.js';
 
 
 /**
@@ -43,7 +44,11 @@ export default class Response {
 		/* Respond based on the given parameters */
 		if (this.response) {
 			if (this.error) {
-				this.errorResponse();
+				if (this.error instanceof UnauthorizedError) {
+					this.notFoundResponse();
+				} else {
+					this.errorResponse();
+				}
 			} else if (content === false) {
 				this.notFoundResponse();
 			} else if (typeof content === 'string') {
@@ -239,7 +244,11 @@ export default class Response {
 	*/
 	async notFoundResponse() {
 		/* Log to the server */
-		console.error('Not Found:', this.request.method && this.request.method.toUpperCase(), this.request.url);
+		if (this.error instanceof UnauthorizedError) {
+			console.error('Not Authorized:', this.request.method && this.request.method.toUpperCase(), this.request.url);
+		} else {
+			console.error('Not Found:', this.request.method && this.request.method.toUpperCase(), this.request.url);
+		}
 
 		/* Respond with the error */
 		if (this.ajax === false) {

--- a/lib/Response.js
+++ b/lib/Response.js
@@ -14,6 +14,7 @@ import Redirect from './Redirect.js';
 import Templating from './Templating.js';
 import Utils from './Utils.js';
 import UnauthorizedError from './UnauthorizedError.js';
+import ValidationError from './ValidationError.js';
 
 
 /**
@@ -46,6 +47,8 @@ export default class Response {
 			if (this.error) {
 				if (this.error instanceof UnauthorizedError) {
 					this.notFoundResponse();
+				} else if (this.error instanceof ValidationError) {
+					this.validationResponse();
 				} else {
 					this.errorResponse();
 				}
@@ -235,6 +238,37 @@ export default class Response {
 			}
 		} else {
 			this.response.status(errorCode).json(this.error.json);
+		}
+	}
+
+
+	/**
+	* Respond with a validation error
+	*/
+	async validationResponse() {
+		/* Log to the server */
+		console.error('Invalid data', this.request.method && this.request.method.toUpperCase(), this.request.url);
+		console.error(this.error);
+
+		/* Respond with the error */
+		if (this.ajax === false) {
+			try {
+				/* Load templating driver */
+				await this.initTemplating();
+
+				/* As a view */
+				this.response.send(await this.templating.renderView(
+					'validation',
+					{
+						error: this.convertArrayToTables(this.error.json.errors),
+						date: new Date(),
+					},
+				));
+			} catch {
+				this.response.status(400).json(this.error.json);
+			}
+		} else {
+			this.response.status(400).json(this.error.json);
 		}
 	}
 

--- a/lib/Storage.js
+++ b/lib/Storage.js
@@ -14,6 +14,7 @@ import { console } from './Cluster.js';
 import SaplingError from './SaplingError.js';
 import Response from './Response.js';
 import Utils from './Utils.js';
+import ValidationError from './ValidationError.js';
 
 
 /* Default user structure */
@@ -378,7 +379,7 @@ export default class Storage {
 		/* Validate the updated data */
 		const errors = this.app.request.validateData(request, response);
 		if (errors.length > 0) {
-			return new Response(this.app, request, response, new SaplingError(errors));
+			return new Response(this.app, request, response, new ValidationError(errors));
 		}
 
 		/* Get the user role from session */
@@ -415,7 +416,7 @@ export default class Storage {
 			if (this.app.uploads) {
 				_.extend(data, await this.app.uploads.handleUpload(request, response, rules));
 			} else {
-				return new Response(this.app, request, response, new SaplingError('File uploads are not allowed'));
+				return new Response(this.app, request, response, new ValidationError('File uploads are not allowed'));
 			}
 		}
 

--- a/lib/UnauthorizedError.js
+++ b/lib/UnauthorizedError.js
@@ -1,7 +1,7 @@
 /**
- * SaplingError
+ * UnauthorizedError
  *
- * Uniform error handling
+ * Handle errors related to insufficient permissions
  */
 
 import SaplingError from './SaplingError.js';

--- a/lib/UnauthorizedError.js
+++ b/lib/UnauthorizedError.js
@@ -1,0 +1,31 @@
+/**
+ * SaplingError
+ *
+ * Uniform error handling
+ */
+
+import SaplingError from './SaplingError.js';
+
+
+/**
+ * The UnauthorizedError class
+ */
+export default class UnauthorizedError extends SaplingError {
+	/**
+	 * Initialise the UnauthorizedError class
+	 */
+	constructor(...parameters) {
+		super(...parameters);
+
+		this.name = 'UnauthorizedError';
+
+		/* Create empty error structure */
+		this.json = {
+			errors: [
+				{
+					title: 'Unauthorized',
+				},
+			],
+		};
+	}
+}

--- a/lib/Uploads.js
+++ b/lib/Uploads.js
@@ -14,10 +14,10 @@ import { unusedFilename } from 'unused-filename';
 import imageSize from 'image-size';
 import sharp from 'sharp';
 
-import SaplingError from './SaplingError.js';
 import Response from './Response.js';
 import Utils from './Utils.js';
 import Validation from './Validation.js';
+import ValidationError from './ValidationError.js';
 
 
 /**
@@ -149,7 +149,7 @@ export default class Uploads {
 
 				/* If there are any errors, give up */
 				if (validator.errors.length > 0) {
-					return new Response(this.app, request, response, new SaplingError(validator.errors));
+					return new Response(this.app, request, response, new ValidationError(validator.errors));
 				}
 
 				/* Move to storage */

--- a/lib/User.js
+++ b/lib/User.js
@@ -8,7 +8,7 @@
 import routeMatcher from 'path-match';
 
 import Response from './Response.js';
-import SaplingError from './SaplingError.js';
+import UnauthorizedError from './UnauthorizedError.js';
 import Utils from './Utils.js';
 
 
@@ -113,7 +113,7 @@ export default class User {
 			&& ((request.permission.role.includes('stranger') && 'user' in request.session)
 			|| (!request.permission.role.includes('stranger') && !('user' in request.session)))
 		) {
-			new Response(this.app, request, response, new SaplingError({
+			new Response(this.app, request, response, new UnauthorizedError({
 				status: '401',
 				code: '4002',
 				title: 'Unauthorized',

--- a/lib/ValidationError.js
+++ b/lib/ValidationError.js
@@ -1,0 +1,24 @@
+/**
+ * ValidationError
+ *
+ * Handle data validation errors
+ */
+
+import SaplingError from './SaplingError.js';
+
+
+/**
+ * The ValidationError class
+ */
+export default class ValidationError extends SaplingError {
+	/**
+	 * Initialise the ValidationError class
+	 *
+	 * @param {any} error The error(s) to be displayed
+	 */
+	constructor(error, ...parameters) {
+		super(error, ...parameters);
+
+		this.name = 'ValidationError';
+	}
+}

--- a/test/core/loadPermissions.test.js
+++ b/test/core/loadPermissions.test.js
@@ -7,6 +7,7 @@ import Request from '../../lib/Request.js';
 import Response from '../../lib/Response.js';
 import SaplingError from '../../lib/SaplingError.js';
 import Storage from '../../lib/Storage.js';
+import UnauthorizedError from '../../lib/UnauthorizedError.js';
 import User from '../../lib/User.js';
 import parseMethodRouteKey from '../../core/parseMethodRouteKey.js';
 
@@ -101,7 +102,7 @@ test.serial('creates middleware', async t => {
 			const response = handler.call(t.context.app, t.context.request, t.context.response, () => true);
 
 			t.true(response instanceof Response);
-			t.is(response.error.message, 'You do not have permission to complete this action.');
+			t.true(response.error instanceof UnauthorizedError);
 		},
 
 		/* Creates post middleware that allows it continue when authorised */


### PR DESCRIPTION
Create new `ValidationError` and `UnauthorizedError` classes to differentiate user-based errors from critical server errors (`SaplingError`), and utilise these everywhere.

Closes #92 