### PR TITLE
Add `verbose` setting for logging

### DIFF
--- a/core/loadConfig.js
+++ b/core/loadConfig.js
@@ -142,6 +142,11 @@ export async function digest() {
 		/* Set immutable production vars */
 		config.strict = true;
 		config.showError = false;
+
+		/* Set verbose to false unless otherwise set */
+		if (!('verbose' in config)) {
+			config.verbose = false;
+		}
 	}
 
 	return config;

--- a/core/loadConfig.js
+++ b/core/loadConfig.js
@@ -10,6 +10,7 @@ import yargs from 'yargs';
 /* eslint-disable-next-line n/file-extension-in-import */
 import { hideBin } from 'yargs/helpers';
 import _ from 'underscore';
+import chalk from 'chalk';
 
 import { console } from '../lib/Cluster.js';
 import SaplingError from '../lib/SaplingError.js';
@@ -157,6 +158,8 @@ export default async function loadConfig(next) {
 	/* Digest config */
 	this.config = await digest.call(this);
 	console.log('CONFIG', this.config);
+	console.logAlways(this.config.production ? chalk.green('Production mode is ON') : chalk.yellow('Production mode is OFF'));
+	console.logAlways(this.config.strict ? chalk.green('Strict mode is ON') : chalk.yellow('Strict mode is OFF'));
 
 	/* Set the app name */
 	this.name = this.config.name;

--- a/core/loadConfig.js
+++ b/core/loadConfig.js
@@ -157,6 +157,11 @@ export async function digest() {
 export default async function loadConfig(next) {
 	/* Digest config */
 	this.config = await digest.call(this);
+
+	/* Set logging verbosity */
+	process.env.VERBOSE_LOGGING = ('verbose' in this.config) ? this.config.verbose : true;
+
+	/* Log config */
 	console.log('CONFIG', this.config);
 	console.logAlways(this.config.production ? chalk.green('Production mode is ON') : chalk.yellow('Production mode is OFF'));
 	console.logAlways(this.config.strict ? chalk.green('Strict mode is ON') : chalk.yellow('Strict mode is OFF'));

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -21,7 +21,7 @@ const originalConsole = console;
 /* Prefixing native console methods with worker ID */
 const prefixedConsole = {
 	log(...args) {
-		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
+		if (process.env.NODE_ENV !== 'test' && Cluster.isVerbose()) {
 			originalConsole.log(Cluster.workerID() + ' '.repeat(currentIndent), ...args);
 		}
 	},
@@ -31,7 +31,7 @@ const prefixedConsole = {
 		}
 	},
 	warn(...args) {
-		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
+		if (process.env.NODE_ENV !== 'test' && Cluster.isVerbose()) {
 			originalConsole.warn(Cluster.workerID() + ' '.repeat(currentIndent), ...args);
 		}
 	},
@@ -41,13 +41,13 @@ const prefixedConsole = {
 		}
 	},
 	group(...args) {
-		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
+		if (process.env.NODE_ENV !== 'test' && Cluster.isVerbose()) {
 			originalConsole.log(Cluster.workerID(), chalk.blue.bold(...args));
 			currentIndent += indentAmount;
 		}
 	},
 	groupEnd() {
-		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
+		if (process.env.NODE_ENV !== 'test' && Cluster.isVerbose()) {
 			currentIndent -= indentAmount;
 		}
 	},
@@ -56,8 +56,6 @@ const prefixedConsole = {
 
 const Cluster = {
 	console: prefixedConsole,
-
-	verbose: true,
 
 	/* Create an access log line */
 	logger(tokens, request, response) {
@@ -83,6 +81,11 @@ const Cluster = {
 		if (process.env.NODE_ENV !== 'test') {
 			console.log(`${chalk.magenta(`Worker ${cluster.worker ? cluster.worker.id : 0} (${pid})`)} now listening on port ${port}`);
 		}
+	},
+
+	/* Return whether verbose logging is on or off */
+	isVerbose() {
+		return process.env.VERBOSE_LOGGING !== 'false';
 	},
 };
 

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -21,12 +21,17 @@ const originalConsole = console;
 /* Prefixing native console methods with worker ID */
 const prefixedConsole = {
 	log(...args) {
+		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
+			originalConsole.log(Cluster.workerID() + ' '.repeat(currentIndent), ...args);
+		}
+	},
+	logAlways(...args) {
 		if (process.env.NODE_ENV !== 'test') {
 			originalConsole.log(Cluster.workerID() + ' '.repeat(currentIndent), ...args);
 		}
 	},
 	warn(...args) {
-		if (process.env.NODE_ENV !== 'test') {
+		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
 			originalConsole.warn(Cluster.workerID() + ' '.repeat(currentIndent), ...args);
 		}
 	},
@@ -36,13 +41,13 @@ const prefixedConsole = {
 		}
 	},
 	group(...args) {
-		if (process.env.NODE_ENV !== 'test') {
+		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
 			originalConsole.log(Cluster.workerID(), chalk.blue.bold(...args));
 			currentIndent += indentAmount;
 		}
 	},
 	groupEnd() {
-		if (process.env.NODE_ENV !== 'test') {
+		if (process.env.NODE_ENV !== 'test' && Cluster.verbose) {
 			currentIndent -= indentAmount;
 		}
 	},
@@ -51,6 +56,8 @@ const prefixedConsole = {
 
 const Cluster = {
 	console: prefixedConsole,
+
+	verbose: true,
 
 	/* Create an access log line */
 	logger(tokens, request, response) {


### PR DESCRIPTION
Add a `verbose` config value to control logging verbosity. `true` by default.

When set to `false`, all `console.log` and `console.warn`s are suppressed. Added a new `console.logAlways` to override the suppression.

Closes #113